### PR TITLE
Add a few optimizations.

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"flag"
 	"fmt"
+	"math/big"
 	"os"
 	"strings"
 	"time"
@@ -11,6 +12,7 @@ import (
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcutil"
+	"github.com/btcsuite/btcutil/base58"
 )
 
 func main() {
@@ -32,28 +34,46 @@ func main() {
 		os.Exit(1)
 	}
 
-	pubkey := btcec.PublicKey{}
-	pubkey.Curve = s256
-
+	var numFound int
+	var x, y *big.Int
+	var zeros [32]byte
+	var serialized [65]byte
+	serialized[0] = 0x04 // Uncompressed pubkeys always start with 0x04.
 	for {
-		pubkey.X, pubkey.Y = s256.ScalarBaseMult(seed)
+		x, y = s256.ScalarBaseMult(seed)
 
-		addr1, err := btcutil.NewAddressPubKey(pubkey.SerializeUncompressed(), net)
-
-		if err != nil {
-			fmt.Printf("failed to get pubkey: %s\n", err)
-			os.Exit(1)
+		// Serialize the pubkey into uncompressed format.
+		xBytes := x.Bytes()
+		if len(xBytes) < 32 {
+			bytesToZero := 32 - len(xBytes)
+			copy(serialized[1:1+bytesToZero], zeros[:bytesToZero])
+			copy(serialized[1+bytesToZero:], xBytes)
+		} else {
+			copy(serialized[1:], xBytes)
+		}
+		yBytes := y.Bytes()
+		if len(yBytes) < 32 {
+			bytesToZero := 32 - len(yBytes)
+			copy(serialized[33:33+bytesToZero], zeros[:bytesToZero])
+			copy(serialized[33+bytesToZero:], yBytes)
+		} else {
+			copy(serialized[33:], yBytes)
 		}
 
-		str1 := addr1.EncodeAddress()
-		if strings.HasPrefix(str1, prefix) {
+		// Encode the address and check the prefix.
+		addr := base58.CheckEncode(btcutil.Hash160(serialized[:]),
+			net.PubKeyHashAddrID)
+		if strings.HasPrefix(addr, prefix) {
 			privkey, _ := btcec.PrivKeyFromBytes(s256, seed)
 			wif, err := btcutil.NewWIF(privkey, net, false)
 			if err != nil {
 				fmt.Printf("failed to get wif: %s\n", err)
 				os.Exit(1)
 			}
-			fmt.Printf("\nElapsed: %s\naddr: %s\nwif: %s\n", time.Since(beginTime), str1, wif.String())
+			numFound++
+			fmt.Printf("\nElapsed: %s\naddr: %s\nwif: %s\nnumfound: %d\n",
+				time.Since(beginTime), addr, wif.String(),
+				numFound)
 		}
 
 		seed[0]--
@@ -61,5 +81,13 @@ func main() {
 			seed[i] = 255
 			seed[i+1]--
 		}
+	}
+}
+
+func init() {
+	// Panic on init if the assumptions used by the code change.
+	if btcec.PubKeyBytesLenUncompressed != 65 {
+		panic("Source code assumes 65-byte uncompressed secp256k1 " +
+			"serialized public keys")
 	}
 }


### PR DESCRIPTION
While it's certainly not as nice to manually serialize the public key and
encode the address from a programming perspective, several allocations can
be avoided by doing so thereby providing a speedup of about 20%.
